### PR TITLE
Feat/menu

### DIFF
--- a/Test-2l7rcl/dist/manifest.json
+++ b/Test-2l7rcl/dist/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "Test-2l7rcl",
-  "name": "Convert SRT to TXT",
+  "name": "Write SRT to TXT File",
   "version": "1.0.0",
   "main": "index.html",
   "manifestVersion": 5,
@@ -36,7 +36,7 @@
       "type": "panel",
       "id": "apps",
       "label": {
-        "default": "Starter Panel"
+        "default": "Show Panel"
       },
       "minimumSize": {
         "width": 230,

--- a/Test-2l7rcl/plugin/manifest.json
+++ b/Test-2l7rcl/plugin/manifest.json
@@ -11,7 +11,7 @@
     }
   ],
   "requiredPermissions": {
-    "localFileSystem": "fullAccess",
+    "localFileSystem": "request",
     "clipboard": "readAndWrite",
     "allowCodeGenerationFromStrings": true,
     "launchProcess": {

--- a/Test-2l7rcl/plugin/manifest.json
+++ b/Test-2l7rcl/plugin/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "Test-2l7rcl",
-  "name": "Convert SRT to TXT",
+  "name": "Write SRT to TXT File",
   "version": "1.0.0",
   "main": "index.html",
   "manifestVersion": 5,
@@ -36,7 +36,7 @@
       "type": "panel",
       "id": "apps",
       "label": {
-        "default": "Starter Panel"
+        "default": "Show Panel"
       },
       "minimumSize": {
         "width": 230,

--- a/Test-2l7rcl/src/components/container.jsx
+++ b/Test-2l7rcl/src/components/container.jsx
@@ -1,19 +1,13 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { StatusComplete } from "./statusComplete";
 import { StatusIncomplete } from "./statusIncomplete";
 import { Header } from "./header";
 import { FileProcessor } from "./fileProcessor";
 import "./container.css"
 
-
 export const Container = () => {
   const [isFileProcessed, setIsFileProcessed] = useState(false)
   const [errorOccurred, setErrorOccurred] = useState(false)
-
-  useEffect(() => {
-    console.log("File Processed Status:", isFileProcessed);
-    console.log("Error Occurred:", errorOccurred);
-  }, [isFileProcessed, errorOccurred]);
 
   return (
     <>

--- a/Test-2l7rcl/src/components/fileProcessor.jsx
+++ b/Test-2l7rcl/src/components/fileProcessor.jsx
@@ -15,10 +15,8 @@ export const FileProcessor = ({ setIsFileProcessed, setErrorOccurred }) => {
         return;
       }
 
-      // store file name
+      // store file name with extension removed
       const fileNameWithoutExtention = file.name.replace(/.srt$/, '').replace(/.mp4$/, '');
-      console.log("fileNameWithoutExtention", fileNameWithoutExtention)
-
       // read file content
       const content = await file.read();
       // console.log("READING FILE", content)
@@ -35,7 +33,6 @@ export const FileProcessor = ({ setIsFileProcessed, setErrorOccurred }) => {
     
       // use original filename for default save name
       const txtFileName = `${fileNameWithoutExtention}`;
-      console.log("text file name", txtFileName)
 
       // select a location to save TXT file
       const txtFile = await fsProvider.getFileForSaving(txtFileName, { types: ['txt'] });

--- a/Test-2l7rcl/src/components/fileProcessor.jsx
+++ b/Test-2l7rcl/src/components/fileProcessor.jsx
@@ -15,11 +15,15 @@ export const FileProcessor = ({ setIsFileProcessed, setErrorOccurred }) => {
         return;
       }
 
+      // store file name
+      const fileNameWithoutExtention = file.name.replace(/.srt$/, '').replace(/.mp4$/, '');
+      console.log("fileNameWithoutExtention", fileNameWithoutExtention)
+
       // read file content
       const content = await file.read();
-      console.log("READING FILE", content)
+      // console.log("READING FILE", content)
       const cleanedText = processSrt(content);
-      console.log("CLEANED TEXT", cleanedText);
+      // console.log("CLEANED TEXT", cleanedText);
 
       if(cleanedText) {
         setIsFileProcessed(true)
@@ -29,8 +33,12 @@ export const FileProcessor = ({ setIsFileProcessed, setErrorOccurred }) => {
         setIsFileProcessed(false)
       }, 5000)
     
-   // select a location to save TXT file
-      const txtFile = await fsProvider.getFileForSaving('cleaned_subtitles.txt', { types: ['txt'] });
+      // use original filename for default save name
+      const txtFileName = `${fileNameWithoutExtention}`;
+      console.log("text file name", txtFileName)
+
+      // select a location to save TXT file
+      const txtFile = await fsProvider.getFileForSaving(txtFileName, { types: ['txt'] });
       console.log(`File content: ${txtFile}`);
       if (!txtFile) {
         console.log('No location selected to save the file');

--- a/Test-2l7rcl/src/components/statusComplete.css
+++ b/Test-2l7rcl/src/components/statusComplete.css
@@ -1,0 +1,12 @@
+.status-complete-container {
+    width: 100%;
+    margin: 10px 0 0 0;
+    padding: 5px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+  
+  .icon-container {
+    padding: 5px 0 0 5px;
+  }

--- a/Test-2l7rcl/src/components/statusComplete.css
+++ b/Test-2l7rcl/src/components/statusComplete.css
@@ -1,4 +1,4 @@
-.status-complete-container {
+.status-container {
     width: 100%;
     margin: 10px 0 0 0;
     padding: 5px;

--- a/Test-2l7rcl/src/components/statusComplete.jsx
+++ b/Test-2l7rcl/src/components/statusComplete.jsx
@@ -4,7 +4,7 @@ import { CheckmarkCircleIcon } from "./checkMarkCircle";
 
 export const StatusComplete = () => {
   return (
-      <div className="status-complete-container">
+      <div className="status-container">
          <sp-body>Complete</sp-body>
         <div className="icon-container">
           <CheckmarkCircleIcon fillColor="#008729" className="checkmark"/>

--- a/Test-2l7rcl/src/components/statusComplete.jsx
+++ b/Test-2l7rcl/src/components/statusComplete.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "./statusComplete.css"
 import { CheckmarkCircleIcon } from "./checkMarkCircle";
 
 export const StatusComplete = () => {

--- a/Test-2l7rcl/src/components/statusComplete.jsx
+++ b/Test-2l7rcl/src/components/statusComplete.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "./statusComplete.css";
 import { CheckmarkCircleIcon } from "./checkMarkCircle";
 
 export const StatusComplete = () => {

--- a/Test-2l7rcl/src/components/statusIncomplete.jsx
+++ b/Test-2l7rcl/src/components/statusIncomplete.jsx
@@ -3,7 +3,7 @@ import { AlertCircleIcon } from "./alertCircle";
 
 export const StatusIncomplete = () => {
   return (
-      <div className="status-complete-container">
+      <div className="status-container">
          <sp-body>Error processing file</sp-body>
         <div className="icon-container">
           <AlertCircleIcon fillColor="#A30B00" className="checkmark"/>


### PR DESCRIPTION
- Change plugin name in manifest.json to "Write SRT to TXT File" and entrypoints panel label to "Show Panel"
- Update `localFileSystem` required permissions to "request" instead of "fullAccess" in manifest.json
- Used the original SRT file name for the default save name of the new text file. Accessed the `.name` property and stored this string in the variable `fileNameWithoutExtention`, then chained two replace prototype methods `replace(/.srt$/, '').replace(/.mp4$/, '')` to remove the file extensions. In the `fsProvider.getFileForSaving()` function, the variable `txtFileName` replaces the hard coded first arg.
- Cleaned up console.logs
- Removed `useEffect` from container.jsx as it was only serving my console.logs
- Updated the shared className "status-container" in `statusComplete.jsx` so that both the `StatusComplete` and `StatusIncomplete` components are styled the same.